### PR TITLE
Ignore empty assets folders when creating list of available assets

### DIFF
--- a/python-scripts/unmatched-asset.py
+++ b/python-scripts/unmatched-asset.py
@@ -153,7 +153,9 @@ def get_assets_files(assets_path):
                                     if season_number:
                                         series['series'][-1]['season_number'].append(season_number)
                 else:
-                    movies['movies'].append({'title': title})
+                    if any('poster' in filename.lower() for filename in files):
+                        movies['movies'].append({'title': title})
+
 
     
     collections['collections'] = sorted(collections['collections'], key=lambda x: x['title'])


### PR DESCRIPTION
PMM can create assets folders if it encounters movies or series in your library that dont have one already. This directory will be empty.
This patch ignores those empty folders, making the list of unmatched usable with this pmm setting enabled.