### PR TITLE
Dont try to set permissions on source and destination dir.

### DIFF
--- a/python-scripts/renamer.py
+++ b/python-scripts/renamer.py
@@ -568,13 +568,6 @@ def main():
                 logger.debug(f"API Key: {'<redacted>' if api else 'None'}")
                 final_output = process_instance(instance_type, instance_name, url, api, final_output, asset_files)
                 print_output(final_output)
-                try:
-                    permissions = 0o777
-                    os.chmod(config.destination_dir, permissions)
-                    os.chmod(config.source_dir, permissions)
-                except Exception as e:
-                    logger.error(e)
-                    pass
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This is unneeded and in cases where the source directory is read-only or owned by another user, this throws an error.