### PR TITLE
Set up multi-platform (linux/amd64, linux/arm64) docker builds in GitHub Actions workflows

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -21,26 +21,33 @@ jobs:
     runs-on: ubuntu-latest
   
     steps:
-      - uses: actions/checkout@v4
-      - name: checkout the repo
-        run: | 
-          docker login --username ${{ secrets.GH_USERNAME }} --password ${{ secrets.GH_TOKEN }} ghcr.io
-          docker build --build-arg BRANCH=$(git rev-parse --abbrev-ref HEAD) -t ghcr.io/drazzilb08/userscripts:dev .
-          docker push ghcr.io/drazzilb08/userscripts:dev
-      
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Login to Docker Hub
         uses: docker/login-action@v3
-        with: 
+        with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
-
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GH_USERNAME }}
+          password: ${{ secrets.GH_TOKEN }}
       - name: Build and push
         id: docker_build
         uses: docker/build-push-action@v5
         with:
           context: .
           file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
           build-args: |
             "BRANCH=dev"
           push: true
-          tags: ${{ secrets.DOCKER_USERNAME }}/userscripts:dev
+          tags: |
+            ${{ secrets.DOCKER_USERNAME }}/userscripts:dev
+            ghcr.io/drazzilb08/userscripts:dev

--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -19,26 +19,35 @@ jobs:
 
   docker-latest:
     runs-on: ubuntu-latest
-  
+
     steps:
-      - uses: actions/checkout@v4
-      - name: checkout the repo
-        run: | 
-          docker login --username ${{ secrets.GH_USERNAME }} --password ${{ secrets.GH_TOKEN }} ghcr.io
-          docker build --build-arg BRANCH=$(git rev-parse --abbrev-ref HEAD) -t ghcr.io/drazzilb08/userscripts:latest .
-          docker push ghcr.io/drazzilb08/userscripts:latest
-      
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Login to Docker Hub
         uses: docker/login-action@v3
-        with: 
+        with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
-
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GH_USERNAME }}
+          password: ${{ secrets.GH_TOKEN }}
       - name: Build and push
         id: docker_build
         uses: docker/build-push-action@v5
         with:
           context: .
           file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            "BRANCH=${{ vars.GITHUB_REF_NAME }}"
           push: true
-          tags: ${{ secrets.DOCKER_USERNAME }}/userscripts:latest
+          tags: |
+            ${{ secrets.DOCKER_USERNAME }}/userscripts:latest
+            ghcr.io/drazzilb08/userscripts:latest

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -11,11 +11,15 @@ jobs:
     runs-on: ubuntu-latest
   
     steps:
-      - name: checkout the repo
+      - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-    
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Get the version
         id: get_version
         run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
@@ -24,18 +28,18 @@ jobs:
         shell: bash
         run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
         id: extract_branch
-        
-      - name: Build GH Container
-        run: | 
-          echo ${{ secrets.GH_TOKEN }} | docker login --username ${{ secrets.GH_USERNAME }} --password-stdin ghcr.io
-          docker build --build-arg BRANCH=${{ steps.extract_branch.outputs.branch }} -t ghcr.io/drazzilb08/userscripts:${{ steps.get_version.outputs.VERSION }} .
-          docker push ghcr.io/drazzilb08/userscripts:${{ steps.get_version.outputs.VERSION }}
-      
+
       - name: Login to Docker Hub
         uses: docker/login-action@v3
-        with: 
+        with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GH_USERNAME }}
+          password: ${{ secrets.GH_TOKEN }}
 
       - name: Build and push
         id: docker_build
@@ -43,7 +47,10 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
           build-args: |
             "BRANCH=${{ steps.extract_branch.outputs.branch }}"
           push: true
-          tags: ${{ secrets.DOCKER_USERNAME }}/userscripts:${{ steps.get_version.outputs.VERSION }}
+          tags: |
+            ${{ secrets.DOCKER_USERNAME }}/userscripts:${{ steps.get_version.outputs.VERSION }}
+            ghcr.io/drazzilb08/userscripts:${{ steps.get_version.outputs.VERSION }}


### PR DESCRIPTION
Using https://docs.docker.com/build/ci/github-actions/push-multi-registries/ as a base, updates the `dev.yml`, `latest.yml`, and `version.yml` workflows to build and push multi-platform docker images for the `linux/amd64` and `linux/arm64` platforms.

Implementation details:
  - Adds `platforms: linux/amd64,linux/arm64` to each `Build and push` step, leveraging the `docker/build-push-action@v5` action's ability to build for multiple platforms at once.
  - Adds the `Set up QEMU` and `Set up Docker Buildx` steps (pre-requisite for multi-platform builds)
  - Cleans up definition of the `Checkout` step (Adds a missing `name` in `dev.yml` and `latest` workflows)
  - Adds a `Login to GitHub Container Registry` step to each workflow
  - Consolidates the GitHub Container Registry build + push into the existing `Build and push` step, leveraging the `docker/build-push-action@v5` action's ability to push to multiple registries at once.
