### PR TITLE
Fix tag creation when the current tags list is empty

### DIFF
--- a/util/arrpy.py
+++ b/util/arrpy.py
@@ -673,23 +673,24 @@ class StARR:
 
     def get_tag_id_from_name(self, tag_name):
         """
-        Get the ID of a tag from its name.
+        Get the ID of a tag from its name. If the tag does not yet
+        exist, it will be created.
         Args:
             tag_name (str): The name of the tag to get the ID for.
         Returns:
             int: The ID of the tag.
         """
-        all_tags = self.get_all_tags()
+        all_tags = self.get_all_tags() or []
         tag_name = tag_name.lower()
-        if all_tags:
-            for tag in all_tags:
-                if tag["label"] == tag_name:
-                    tag_id = tag["id"]
-                    return tag_id
-            else:
-                tag_id = self.create_tag(tag_name)
+
+        for tag in all_tags:
+            if tag["label"] == tag_name:
+                tag_id = tag["id"]
                 return tag_id
-        return None
+
+        # If the tag doesn't already exist, create it.
+        tag_id = self.create_tag(tag_name)
+        return tag_id
     
     def remove_item_from_queue(self, queue_ids):
         """


### PR DESCRIPTION
Fixes a bug where tags would not be created when the list of existing tags is empty.

Specifically, the bug was at this line:

```py
        if all_tags:
          # ... doesn't run when all_tags is []

        return None
```

when `all_tags` was an empty list `[]`.

In Python, [empty lists are considered "falsy"](https://stackoverflow.com/a/39984051) and therefore fail the `if` condition check.