### PR TITLE
Disable tqdm when no TTY is detected

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,8 +5,10 @@ import multiprocessing
 import os
 import sys
 import time
+from functools import partialmethod
 
 from prettytable import PrettyTable
+from tqdm import tqdm
 from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
 
@@ -30,6 +32,9 @@ list_of_python_modules = [
     "unmatched_assets",
     "jduparr",
 ]
+
+# Disable tqdm when no tty is detected
+tqdm.__init__ = partialmethod(tqdm.__init__, disable=None)
 
 
 class ScheduleFileHandler(FileSystemEventHandler):
@@ -249,7 +254,6 @@ def main():
                 waiting_message_shown = True
 
             for module_name, schedule_time in current_schedule.items():
-
                 if manager.is_already_running(module_name) or not schedule_time:
                     continue
 


### PR DESCRIPTION
When no TTY is detected, tqdm should be disabled.

When tqdm is enabled without a TTY being detected, it will start breaking with a `Broken pipe` error more often than not.

I opted to override the tqdm `__init__` function in `main.py` so I did not have to change any specific call to `tqdm()` nor do we have to worry about it in the future if we add `tqdm()` calls in new code.
But if you want the `disable=None` set on the `tqdm()` calls let me know and I can change the code.

As stated in the issue report, I have been running this code for some time now and I have not seen any errors anymore.
Update is tested both with my cronjob that runs twice a day, and with some manual calls on the cli. Cron output no longer has the progress bar output, the cli calls have.

Closes #253 
Should be applied to both `dev` and `master` as both use the same setup and the patch applies cleanly on both