### PR TITLE
Fix - nohl module: Movie matching for Radarr

### DIFF
--- a/modules/nohl.py
+++ b/modules/nohl.py
@@ -55,11 +55,21 @@ def find_nohl_files(
         if item.startswith("."):
             continue
         # Remove year from directory name for title
-        title = re.sub(year_regex, "", item)
-        try:
-            year = int(year_regex.search(item).group(1))
+try:
+            year_match = year_regex.search(item)
+            year = int(year_match.group(1))
+            
+            # Split the string at the year location and take the first part
+            # This ensures we drop '-(tt123...)' suffixes
+            start_index = year_match.start()
+            raw_title = item[:start_index]
+            
+            # clean up trailing dots or dashes left over
+            title = raw_title.rstrip(".- ")
         except AttributeError:
+            # Fallback if year isn't found
             year = 0
+            title = item
         asset_list: Dict[str, Any] = {
             "title": title,
             "year": year,

--- a/modules/nohl.py
+++ b/modules/nohl.py
@@ -54,20 +54,18 @@ def find_nohl_files(
     ):
         if item.startswith("."):
             continue
-        # Remove year from directory name for title
-        try:
-            year_match = year_regex.search(item)
-            year = int(year_match.group(1))
-            
-            # Split the string at the year location and take the first part
-            # This ensures we drop '-(tt123...)' suffixes
-            start_index = year_match.start()
-            raw_title = item[:start_index]
-            
-            # clean up trailing dots or dashes left over
-            title = raw_title.rstrip(".- ")
-        except AttributeError:
-            # Fallback if year isn't found
+        # Find and remove year from directory name for title
+        year_match = re.search(r"(?:^|[. (_-])((?:19|20)\d{2})(?:$|[. )_-])", item)
+
+        if year_match:
+            try:
+                year = int(year_match.group(1))
+                
+                title = item[:year_match.start(1)].rstrip(" .-_()")
+            except ValueError:
+                year = 0
+                title = item
+        else:
             year = 0
             title = item
         asset_list: Dict[str, Any] = {

--- a/modules/nohl.py
+++ b/modules/nohl.py
@@ -55,7 +55,7 @@ def find_nohl_files(
         if item.startswith("."):
             continue
         # Remove year from directory name for title
-try:
+        try:
             year_match = year_regex.search(item)
             year = int(year_match.group(1))
             


### PR DESCRIPTION
Folder names follow a format common with Trash Guides/Radarr custom formats, which includes external IDs at the end: For example: `The.Movie.Name.1983-(tt0082158-8305)`

The current logic results in `The.Movie.Name.-(tt0082158-8305)`

So we need to explicitly remove the -(tt...) suffix or anything trailing the year.