### PR TITLE
Implement filtering of ignored collections

### DIFF
--- a/modules/unmatched_assets.py
+++ b/modules/unmatched_assets.py
@@ -244,6 +244,19 @@ def main(config: SimpleNamespace) -> None:
                                 include_smart=True,
                                 collections_only=True,
                             )
+                            
+                            # Filter out ignored collections
+                            ignore_collections = getattr(config, 'ignore_collections', [])
+                            if ignore_collections:
+                                logger.info(f"Filtering {len(ignore_collections)} ignored collections...")
+                                filtered_results = []
+                                for collection in results:
+                                    if collection['title'] not in ignore_collections:
+                                        filtered_results.append(collection)
+                                    else:
+                                        logger.debug(f"Ignoring collection: {collection['title']}")
+                                results = filtered_results
+                            
                             media_dict["collections"].extend(results)
                         else:
                             logger.warning(


### PR DESCRIPTION
-Add collection filtering by title after fetching from Plex
-Use existing ignore_collections config field from template 
-Add logging for filtered collections
-Follows same pattern as ignore_media in poster_cleanarr

Testing

-Tested by mounting the modified script in docker
-Collections in ignore list were filtered out
-Logging confirms that collections are being ignored
-No impact on movies or series processing
-Works correctly when ignore_collections list is empty